### PR TITLE
Allow using any compatible version of js-toml and typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
 		"chokidar": "^5.0.0",
 		"comment-json": "^5.0.0",
 		"execa": "^9.6.1",
-		"js-toml": "1.1.0",
-		"typescript": "6.0.3",
+		"js-toml": "^1.1.0",
+		"typescript": "^6.0.3",
 		"wabt": "^1.0.39"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
Using "[caret ranges](https://github.com/npm/node-semver#caret-ranges-123-025-004)" allows dependents of rsbuild-plugin-wasmpack to use newer compatible versions of those packages without having to wait for a new rsbuild-plugin-wasmpack release.